### PR TITLE
Fix compile error from deprecated Texture2D.LoadImage();

### DIFF
--- a/VideoPlayer/Util/Base64Sprites.cs
+++ b/VideoPlayer/Util/Base64Sprites.cs
@@ -46,7 +46,8 @@ namespace MusicVideoPlayer.Util
             Texture2D texture = new Texture2D(0, 0, TextureFormat.ARGB32, false, true);
             texture.hideFlags = HideFlags.HideAndDontSave;
             texture.filterMode = FilterMode.Trilinear;
-            texture.LoadImage(imageData);
+            texture.LoadRawTextureData(imageData);
+            texture.Apply();
             return texture;
         }
     }


### PR DESCRIPTION
With BS 13.0 from the Oculus store texture.LoadImage() was removed from their UnityEngine.CoreModule.dll